### PR TITLE
Include the pyjs compiler script in pypi distribution.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author = "Pyjaco development team",
     author_email = "developer@pyjaco.org",
     description = ("Python to JavaScript translator"),
+    scripts = ["pyjs.py"],
     url = "http://pyjaco.org",
     keywords = "python javascript translator compiler",
     packages=["pyjaco", "pyjaco.compiler"],


### PR DESCRIPTION
I tested this in a virtualenv and it worked.

You may want to rename this script; I get the impression you're no longer calling it pyjs. However, calling it pyjaco would conflict with the pyjaco module in the source distribution.
