### PR TITLE
Create a pyjaco example that utilizes jQuery.

### DIFF
--- a/examples/jquery/README
+++ b/examples/jquery/README
@@ -1,0 +1,16 @@
+An example of using pyjaco to build a stand-alone javascript file that can be
+included with HTML. I like this method as it allows separating javascript from
+HTML and can therefore be used with a variety of backend setups.
+
+First run the following command in the main pyjaco directory:
+
+# python generate_library.py
+
+This will create the py-builtins.js that is included in the index.html file
+
+Next, generate the clicker.js javascript from clicker.py:
+
+python pyjs.py -N --output clicker.js 
+
+Now you can load index.html in a browser and click the heading for a simple
+jQuery interaction.

--- a/examples/jquery/clicker.py
+++ b/examples/jquery/clicker.py
@@ -1,0 +1,16 @@
+@JSVar("jQuery")
+def ready():
+    jQuery('h1').click(on_click)
+
+@JSVar("jQuery", "Math.random", "Math.floor")
+def on_click():
+    if jQuery('#when_clicked').html():
+        r = Math.floor(Math.random() * 255)
+        g = Math.floor(Math.random() * 255)
+        b = Math.floor(Math.random() * 255)
+        color = "rgb(%d, %d, %d)" %(r,g,b)
+        jQuery('#when_clicked').attr('style', 'background-color: ' + color)
+    else:
+        jQuery('#when_clicked').html("you clicked it!")
+
+jQuery(ready)

--- a/examples/jquery/index.html
+++ b/examples/jquery/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html> 
+<html> 
+	<head> 
+    <script type="text/javascript" src="http://code.jquery.com/jquery-1.6.4.min.js"></script>
+    <script type="text/javascript" src="../../py-builtins.js"></script>
+    <script type="text/javascript" src="clicker.js"></script>
+  </head> 
+<body> 
+  <h1>Click me</h1>
+  <p id="when_clicked"></p>
+</body>
+</html>


### PR DESCRIPTION
This example uses the pyjs.py script to compile a single javascript file.

It demonstrates several things I think a user might want to do that are not covered in the current examples:
- use pyjaco with jquery
- compile a single python file into a javascript file
- include that external file in an HTML file (thus it could also be included in a Django template or CherryPy static file, etc)

I've also written a blog post documenting the process; you may want to link to it or include it in your documentation: http://archlinux.me/dusty/2011/12/27/pyjaco-and-jquery/
