### PR TITLE
Several improvements to pyjs.py

### DIFF
--- a/pyjs.py
+++ b/pyjs.py
@@ -5,6 +5,7 @@ import os.path
 from optparse import OptionParser
 from pyjaco import Compiler
 
+# FIXME: This hardcoding is undesirable
 if os.path.exists("py-builtins.js"):
     path_library = "py-builtins.js"
 else:
@@ -23,7 +24,8 @@ def main():
             action = "store",
             dest = "builtins",
             choices = ["include", "import", "generate", "none"],
-            default = "none")
+            default = "none",
+            help = "INCLUDE builtins statically in each file\nIMPORT builtins using a load statement in each file\nGENERATE a separate file for builtins (output must be a directory)\nNONE don't include builtins")
 
     options, args = parser.parse_args()
 
@@ -41,10 +43,19 @@ def main():
             output = sys.stdout
 
         if options.builtins in ("include", "generate"):
+            if options.builtins == "include":
+                builtin_output = output
+            else:
+                builtin_filename = os.path.abspath(os.path.join(os.path.dirname(
+                    filename), "py-builtins.js"))
+                builtin_output = open(builtin_filename, "w")
+
             builtins = open(path_library).read()
-            output.write("/*%s*/\n" % "  Standard library  ".center(76, "*"))
-            output.write(builtins)
-            output.write("/*%s*/\n" % "  User code  ".center(76, "*"))
+
+            builtin_output.write("/*%s*/\n" % "  Standard library  ".center(76, "*"))
+            builtin_output.write(builtins)
+            if options.builtins == "include":
+                builtin_output.write("/*%s*/\n" % "  User code  ".center(76, "*"))
         elif options.builtins == "import":
             output.write('load("%s");\n' % path_library)
 

--- a/pyjs.py
+++ b/pyjs.py
@@ -19,29 +19,15 @@ def main():
                       dest   = "output",
                       help   = "write output to OUTPUT, can be a file or directory")
 
-    parser.add_option("-i", "--include-builtins",
-                      action  = "store_true",
-                      dest    = "include_builtins",
-                      default = False,
-                      help    = "include py-builtins.js library in the output")
-
-    parser.add_option("-I", "--import-builtins",
-                      action  = "store_true",
-                      dest    = "import_builtins",
-                      default = False,
-                      help    = "call load('py-builtins.js') to source the standard library")
-
-    parser.add_option("-N", "--no-include",
-                      action  = "store_true",
-                      dest    = "no_builtins",
-                      default = False,
-                      help    = "Do not include attempt to load py-builtins.js. The generated javascript code will not run by itself, unless this library is included")
+    parser.add_option("-b", "--builtins",
+            action = "store",
+            dest = "builtins",
+            choices = ["include", "import", "generate", "none"],
+            default = "none")
 
     options, args = parser.parse_args()
 
-    if options.include_builtins + options.import_builtins + options.no_builtins <> 1 and len(args) == 1:
-        print "You must specify either the -i, -I or -N mode!"
-    elif len(args) == 1:
+    if len(args) == 1:
         filename = args[0]
 
         if options.output:
@@ -54,12 +40,12 @@ def main():
         else:
             output = sys.stdout
 
-        if options.include_builtins:
+        if options.builtins in ("include", "generate"):
             builtins = open(path_library).read()
             output.write("/*%s*/\n" % "  Standard library  ".center(76, "*"))
             output.write(builtins)
             output.write("/*%s*/\n" % "  User code  ".center(76, "*"))
-        elif options.import_builtins:
+        elif options.builtins == "import":
             output.write('load("%s");\n' % path_library)
 
         c = Compiler()

--- a/pyjs.py
+++ b/pyjs.py
@@ -17,7 +17,7 @@ def main():
     parser.add_option("-o", "--output",
                       action = "store",
                       dest   = "output",
-                      help   = "write output to OUTPUT")
+                      help   = "write output to OUTPUT, can be a file or directory")
 
     parser.add_option("-i", "--include-builtins",
                       action  = "store_true",
@@ -45,7 +45,12 @@ def main():
         filename = args[0]
 
         if options.output:
-            output = open(options.output, "w")
+            if os.path.isdir(options.output):
+                output_filename = os.path.splitext(os.path.basename(filename))[0]
+                output_filename += ".js"
+                output = open(os.path.join(options.output, output_filename), "w")
+            else:
+                output = open(options.output, "w")
         else:
             output = sys.stdout
 

--- a/pyjs.py
+++ b/pyjs.py
@@ -4,6 +4,7 @@ import sys
 import os.path
 import datetime
 import time
+import traceback
 from optparse import OptionParser
 from pyjaco import Compiler
 
@@ -124,7 +125,11 @@ class Monitor:
         run_once(self.input_filename, self.options)
         while True:
             if self.code_changed():
-                run_once(self.input_filename, self.options)
+                try:
+                    run_once(self.input_filename, self.options)
+                except Exception as e:
+                    traceback.print_exc(file=sys.stderr)
+
             time.sleep(1)
 
 

--- a/pyjs.py
+++ b/pyjs.py
@@ -5,6 +5,9 @@ import os.path
 from optparse import OptionParser
 from pyjaco import Compiler
 
+# extensions of files that can be compiled to .js
+VALID_EXTENSIONS = ['.py', '.pyjaco']
+
 # FIXME: This hardcoding is undesirable
 if os.path.exists("py-builtins.js"):
     path_library = "py-builtins.js"
@@ -46,7 +49,7 @@ def run_once(input_filename, options):
         if not options.output or not os.path.isdir(options.output):
             parser.error("--output must be a directory if the input file is a directory")
 
-        input_filenames = [f for f in os.listdir(input_filename) if os.path.splitext(f)[1] in (".py", ".pyjaco")]
+        input_filenames = [f for f in os.listdir(input_filename) if os.path.splitext(f)[1] in VALID_EXTENSIONS]
         for filename in input_filenames:
             output_filename = os.path.splitext(os.path.basename(filename))[0]
             output_filename += ".js"

--- a/pyjs.py
+++ b/pyjs.py
@@ -14,7 +14,7 @@ def main():
     parser = OptionParser(usage="%prog [options] filename",
                           description="Python to JavaScript compiler.")
 
-    parser.add_option("--output",
+    parser.add_option("-o", "--output",
                       action = "store",
                       dest   = "output",
                       help   = "write output to OUTPUT")


### PR DESCRIPTION
Hi Christian,

I have made a few major improvements to pyjs.py that I hope you will like. Before describing them, I want to highlight one thing you may not like, as it is backwards incompatible:

I removed the -i, -I, -N options and combined them into a single -b option that can take a value of import, include, none, or a new generate option that I invented; I also made it default to none. I think this makes more sense since the options are mutually exclusive. The negative is anybody who is already using the script will have to change their habits and any scripts that use these options. I gambled that this would not be an issue since you said the script is not the expected way to use pyjaco (I anticipate this changing as I continue to evolve the script ;-) )

Changes I made include:
- allow specifying an output directory as well as output file. The output filename is created by changing the file extension of the input file to .js
- allow specifying an input directory. In this case, all files in that directory that have extensions of .py or .pyjaco will be compiled to .js files with the same name.
- allow generating the standard library file in the output directory
- open files using context managers to be more explicit about closing resources

Let me know if there is anything you dislike in this code before I continue with the directory watching code.

Also, what python versions are you targeting? It would be cool to switch from optparse to argparse, but argparse is only shipped with python2.7 and above.
